### PR TITLE
Fix build failure after CentOS 8 gone EOL

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -110,6 +110,10 @@ useradd -u 2000 -g 2000 zerotier-one
 groupadd -g 2001 ztncui
 useradd -u 2001 -g 2001 ztncui
 
+# Fix for CentOS 8 gone EOL: Change base URL for package repos to vault.centos.org
+sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+sed -i 's|^#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 echo
 echo '*** Installing zerotier-one package...'
 


### PR DESCRIPTION
Centos 8 has gone EOL, and its package repos have been moved to the "vault", which is a different hostname. This is causing `dnf install` commands to fail during the docker build process.

Build script now amends base centos yum repo files, to use the correct base url for fetching packages.